### PR TITLE
Add basic support for Gleam

### DIFF
--- a/treesit-fold-parsers.el
+++ b/treesit-fold-parsers.el
@@ -264,6 +264,17 @@
      . (lambda (node offset)
          (treesit-fold-range-line-comment node offset "#")))))
 
+(defun treesit-fold-parsers-gleam ()
+  "Rules set for Gleam."
+  '((function        . treesit-fold-range-gleam)
+    (type_definition . treesit-fold-range-gleam)
+    (module_comment
+     . (lambda (node offset)
+         (treesit-fold-range-line-comment node offset "////")))
+    (statement_comment
+     . (lambda (node offset)
+         (treesit-fold-range-line-comment node offset "///")))))
+
 (defun treesit-fold-parsers-glsl ()
   "Rule set for GLSL."
   '((field_declaration_list . treesit-fold-range-seq)

--- a/treesit-fold.el
+++ b/treesit-fold.el
@@ -96,6 +96,7 @@
     (fish-mode              . ,(treesit-fold-parsers-fish))
     (gdscript-mode          . ,(treesit-fold-parsers-gdscript))
     (gdscript-ts-mode       . ,(treesit-fold-parsers-gdscript))
+    (gleam-ts-mode          . ,(treesit-fold-parsers-gleam))
     (glsl-mode              . ,(treesit-fold-parsers-glsl))
     (go-mode                . ,(treesit-fold-parsers-go))
     (go-ts-mode             . ,(treesit-fold-parsers-go))
@@ -876,6 +877,18 @@ For arguments NODE and OFFSET, see function `treesit-fold-range-seq' for
 more information."
   (when-let* ((beg (treesit-node-start node))
               (beg (treesit-fold--eol beg))
+              (end (treesit-node-end node))
+              (end (1- end)))
+    (treesit-fold--cons-add (cons beg end) offset)))
+
+(defun treesit-fold-range-gleam (node offset)
+  "Return the fold range for `function' `type_definition' NODE in Gleam.
+
+For arguments NODE and OFFSET, see function `treesit-fold-range-seq' for
+more information."
+  (when-let* ((open-bracket (car (treesit-fold-find-children node "{")))
+              (beg (treesit-node-start open-bracket))
+              (beg (1+ beg))
               (end (treesit-node-end node))
               (end (1- end)))
     (treesit-fold--cons-add (cons beg end) offset)))


### PR DESCRIPTION
This PR adds support for Gleam via [gleam-ts-mode](https://github.com/gleam-lang/gleam-mode/commits/gleam-ts-mode/). The major mode is not available on ELPA/MELPA yet, but it is under the `gleam-lang` org, and it claims to be "eventually hosted on MELPA".

The content is pretty basic. I wasn't sure how I was able to use `treesit-fold-line-comment-mode`, so the comment definitions are untested, but I have followed other languages.