### PR TITLE
2 bug fix

### DIFF
--- a/treesit-fold-indicators.el
+++ b/treesit-fold-indicators.el
@@ -353,7 +353,8 @@ Optional arguments WEND and WSTART are the range for caching."
           (wstart (window-start))
           (nodes-to-fold
            (cl-remove-if-not (lambda (node)
-                               (treesit-fold-indicators--within-window (cdr node) wend wstart))
+                               (ignore-errors
+                                 (treesit-fold-indicators--within-window (cdr node) wend wstart)))
                              nodes-to-fold))
           (mode-ranges (alist-get major-mode treesit-fold-range-alist))
           (nodes-to-fold

--- a/treesit-fold.el
+++ b/treesit-fold.el
@@ -292,9 +292,10 @@ For example, Lua, Ruby, etc."
 
 (defun treesit-fold--trigger ()
   "Toggle `treesit-fold-mode' when the current mode is treesit-fold compatible."
-  (if (and (treesit-fold-ready-p) (treesit-fold-usable-mode-p))
-      (treesit-fold-mode 1)
-    (treesit-fold-mode -1)))
+  (when (treesit-fold-ready-p)
+    (if (treesit-fold-usable-mode-p)
+        (treesit-fold-mode 1)
+      (treesit-fold-mode -1))))
 
 ;;;###autoload
 (define-minor-mode treesit-fold-mode


### PR DESCRIPTION
1. fix: call treesit-fold-mode only when treesit-fold-ready-p

If `treesit-fold-ready-p` is false, `(treesit-fold-mode -1)` will get an
error since it will call `treesit-fold-open-all`.

2. fix: Ignore errors for the filter when indicators refresh

When the buffer is being edited, the node might change and become
invalid which will cause errors. And these errors should be ignored or
they will infect other post command hooks.
