### PR TITLE
Use built-in define-globalized-minor-mode

### DIFF
--- a/treesit-fold-indicators.el
+++ b/treesit-fold-indicators.el
@@ -117,15 +117,12 @@
 
 (defun treesit-fold-indicators--enable ()
   "Enable `treesit-fold-indicators' mode."
-  (if (or treesit-fold-mode (treesit-fold-mode 1))  ; Enable `treesit-fold-mode' automatically
-      (progn
-        (add-hook 'after-change-functions #'treesit-fold-indicators--trigger-render nil t)
-        (add-hook 'after-save-hook #'treesit-fold-indicators--trigger-render nil t)
-        (add-hook 'post-command-hook #'treesit-fold-indicators--post-command nil t)
-        (add-hook 'window-size-change-functions #'treesit-fold-indicators--size-change)
-        (add-hook 'window-scroll-functions #'treesit-fold-indicators--scroll)
-        (treesit-fold-indicators--render-buffer))
-    (treesit-fold-indicators-mode -1)))
+  (add-hook 'after-change-functions #'treesit-fold-indicators--trigger-render nil t)
+  (add-hook 'after-save-hook #'treesit-fold-indicators--trigger-render nil t)
+  (add-hook 'post-command-hook #'treesit-fold-indicators--post-command nil t)
+  (add-hook 'window-size-change-functions #'treesit-fold-indicators--size-change)
+  (add-hook 'window-scroll-functions #'treesit-fold-indicators--scroll)
+  (treesit-fold-indicators--render-buffer))
 
 (defun treesit-fold-indicators--disable ()
   "Disable `treesit-fold-indicators' mode."
@@ -143,31 +140,25 @@
   :lighter nil
   :keymap treesit-fold-indicators-mode-map
   :init-value nil
-  (if treesit-fold-indicators-mode
-      (treesit-fold-indicators--enable)
-    (treesit-fold-indicators--disable)))
+  (cond
+   ((not (and (or treesit-fold-mode (treesit-fold-mode 1))
+              treesit-fold-indicators-mode))
+    (when treesit-fold-indicators-mode
+      (treesit-fold-indicators-mode -1)))
+   (treesit-fold-indicators-mode
+    (treesit-fold-indicators--enable) t)
+   (t
+    (treesit-fold-indicators--disable))))
 
 ;;;###autoload
-(define-minor-mode global-treesit-fold-indicators-mode
-  "Toggle treesit-fold-indicatos in all buffers avaliable."
-  :group 'treesit-fold
-  :lighter nil
-  :init-value nil
-  :global t
-  (cond (global-treesit-fold-indicators-mode
-         (add-hook 'treesit-fold-mode-hook #'treesit-fold-indicators-mode)
-         (global-treesit-fold-mode 1)  ; Must enabled!
-         (dolist (buf (buffer-list))
-           (with-current-buffer buf
-             (when (and treesit-fold-mode (not treesit-fold-indicators-mode))
-               (treesit-fold-indicators-mode 1)))))
-        (t
-         (remove-hook 'treesit-fold-mode-hook #'treesit-fold-indicators-mode)
-         (dolist (buf (buffer-list))
-           (with-current-buffer buf
-             (when (and treesit-fold-mode treesit-fold-indicators-mode)
-               (treesit-fold-indicators-mode -1)))))))
+(define-globalized-minor-mode global-treesit-fold-indicators-mode
+  treesit-fold-indicators-mode treesit-fold-indicators--trigger
+  :group 'treesit-fold)
 
+(defun treesit-fold-indicators--trigger ()
+  (when (or treesit-fold-mode
+            (treesit-fold-mode 1))
+    (treesit-fold-indicators-mode)))
 ;;
 ;; (@* "Events" )
 ;;

--- a/treesit-fold-indicators.el
+++ b/treesit-fold-indicators.el
@@ -156,9 +156,11 @@
   :group 'treesit-fold)
 
 (defun treesit-fold-indicators--trigger ()
+  "Enable `treesit-fold-indicators-mode' when `treesit-fold-mode' can
+be enabled."
   (when (or treesit-fold-mode
             (treesit-fold-mode 1))
-    (treesit-fold-indicators-mode)))
+    (treesit-fold-indicators-mode 1)))
 ;;
 ;; (@* "Events" )
 ;;

--- a/treesit-fold.el
+++ b/treesit-fold.el
@@ -252,6 +252,8 @@ For example, Lua, Ruby, etc."
   "Modes in which `treesit-fold-mode' gets enabled."
   :type '(repeat symbol))
 
+(defvar-keymap treesit-fold-mode-map
+  :doc "Keymap used when `treesit-fold-mode' is active.")
 ;;
 ;; (@* "Externals" )
 ;;
@@ -292,10 +294,9 @@ For example, Lua, Ruby, etc."
 
 (defun treesit-fold--trigger ()
   "Toggle `treesit-fold-mode' when the current mode is treesit-fold compatible."
-  (when (treesit-fold-ready-p)
-    (if (treesit-fold-usable-mode-p)
-        (treesit-fold-mode 1)
-      (treesit-fold-mode -1))))
+  (when (and (treesit-fold-ready-p)
+             (treesit-fold-usable-mode-p))
+    (treesit-fold-mode 1)))
 
 ;;;###autoload
 (define-minor-mode treesit-fold-mode
@@ -303,25 +304,22 @@ For example, Lua, Ruby, etc."
   :group 'treesit-fold
   :init-value nil
   :lighter "Treesit-Fold"
-  (if treesit-fold-mode (treesit-fold--enable) (treesit-fold--disable)))
+  :keymap treesit-fold-mode-map
+  (cond
+   ((not (and (treesit-available-p)
+              (treesit-parser-list)
+              (treesit-fold-usable-mode-p)))
+    (when treesit-fold-mode
+      (treesit-fold-mode -1)))
+   (treesit-fold-mode
+    (treesit-fold--enable) t)
+   (t
+    (treesit-fold--disable))))
 
 ;;;###autoload
-(define-minor-mode global-treesit-fold-mode
-  "Use `treesit-fold-mode' wherever possible."
-  :group 'treesit-fold
-  :init-value nil
-  :lighter nil
-  :global t
-  (if global-treesit-fold-mode
-      (progn
-        (dolist (hook (mapcar (lambda (m) (intern (format "%s-hook" m))) treesit-fold-modes))
-          (add-hook hook #'treesit-fold--trigger))
-        ;; try to turn on in all buffers.
-        (dolist (buf (buffer-list))
-          (with-current-buffer buf
-            (treesit-fold--trigger))))
-    (dolist (hook (mapcar (lambda (m) (intern (format "%s-hook" m))) treesit-fold-modes))
-      (remove-hook hook #'treesit-fold--trigger))))
+(define-globalized-minor-mode global-treesit-fold-mode
+  treesit-fold-mode treesit-fold--trigger
+  :group 'treesit-fold)
 
 (defun treesit-fold-usable-mode-p (&optional mode)
   "Return non-nil if `treesit-fold' has defined folds for MODE."

--- a/treesit-fold.el
+++ b/treesit-fold.el
@@ -293,7 +293,7 @@ For example, Lua, Ruby, etc."
   (treesit-parser-list))
 
 (defun treesit-fold--trigger ()
-  "Toggle `treesit-fold-mode' when the current mode is treesit-fold compatible."
+  "Enable `treesit-fold-mode' when the current mode is treesit-fold compatible."
   (when (and (treesit-fold-ready-p)
              (treesit-fold-usable-mode-p))
     (treesit-fold-mode 1)))


### PR DESCRIPTION
This PR is to standardize the global activation of both treesit-fold &
treesit-fold-indicators modes.