### PR TITLE
Add HEEx support

### DIFF
--- a/treesit-fold-parsers.el
+++ b/treesit-fold-parsers.el
@@ -314,6 +314,12 @@
   '((block    . treesit-fold-range-seq)
     (comment  . treesit-fold-range-c-like-comment)))
 
+(defun treesit-fold-parsers-heex ()
+  "Rule set for Heex."
+  '((tag . treesit-fold-range-html)
+    (component . treesit-fold-range-html)
+    (comment . (treesit-fold-range-seq 1 -1))))
+
 (defun treesit-fold-parsers-hlsl ()
   "Rule set for HLSL."
   '((field_declaration_list . treesit-fold-range-seq)

--- a/treesit-fold-summary.el
+++ b/treesit-fold-summary.el
@@ -223,6 +223,7 @@ type of content by checking the word boundary's existence."
     (jenkinsfile-mode       . treesit-fold-summary-javadoc)
     (haskell-mode           . treesit-fold-summary-lua-doc)
     (haxe-mode              . treesit-fold-summary-javadoc)
+    (heex-mode              . treesit-fold-summary-xml)
     (hlsl-mode              . treesit-fold-summary-c)
     (html-mode              . treesit-fold-summary-xml)
     (jai-mode               . treesit-fold-summary-c)

--- a/treesit-fold.el
+++ b/treesit-fold.el
@@ -106,6 +106,8 @@
     (haskell-mode           . ,(treesit-fold-parsers-haskell))
     (haskell-ts-mode        . ,(treesit-fold-parsers-haskell))
     (haxe-mode              . ,(treesit-fold-parsers-haxe))
+    (heex-mode              . ,(treesit-fold-parsers-heex))
+    (heex-ts-mode           . ,(treesit-fold-parsers-heex))
     (hlsl-mode              . ,(treesit-fold-parsers-hlsl))
     (hlsl-ts-mode           . ,(treesit-fold-parsers-hlsl))
     (html-mode              . ,(treesit-fold-parsers-html))


### PR DESCRIPTION
This PR adds support for [HEEx templates](https://hexdocs.pm/phoenix/components.html), which are used in Elixir Phoenix. `heex-ts-mode` is shipped with Emacs HEAD.