### PR TITLE
fix(indicators): refresh indicators only when the mode is enabled

### DIFF
--- a/treesit-fold.el
+++ b/treesit-fold.el
@@ -563,7 +563,9 @@ If the current syntax node is not foldable, do nothing."
 
 (defun treesit-fold--after-command (&rest _)
   "Function call after interactive commands."
-  (treesit-fold-indicators-refresh))
+  (when (and (boundp 'treesit-fold-indicators-mode)
+             treesit-fold-indicators-mode)
+    (treesit-fold-indicators-refresh)))
 
 (let ((commands '(treesit-fold-close
                   treesit-fold-open


### PR DESCRIPTION
fix function is void question without using treesit-fold-indicators.

Heeeeee~~, 
Thank you for your work. I like this package very much. I encountered a problem in using it. I fixed it here.


test.el
```emacs-lisp
(use-package treesit-fold
  :ensure nil
  :load-path "/path/treesit-fold/")
```
main.c
```C
void main(void) {
  // Emacs cursor here, use treesit-fold-toggle
  printf("Hello World!!");
}
```
On main.c file Use:
`M-x treesit-fold-mode RET`
`M-x treesit-fold-toggle RET`
