### PR TITLE
feat: Add space in minor mode lighter

### DIFF
--- a/treesit-fold.el
+++ b/treesit-fold.el
@@ -303,7 +303,7 @@ For example, Lua, Ruby, etc."
   "Folding code using tree sitter."
   :group 'treesit-fold
   :init-value nil
-  :lighter "Treesit-Fold"
+  :lighter " Treesit-Fold"
   :keymap treesit-fold-mode-map
   (cond
    ((not (and (treesit-available-p)


### PR DESCRIPTION
It is a convention to add head space in minor mode lighter to avoid join with other minor mode lighters.
![1](https://github.com/user-attachments/assets/9fd60b60-19a6-4f13-a6b7-6222136964e6)
![2](https://github.com/user-attachments/assets/00ad88ac-1ae1-4514-a9b6-fc4dce5e2424)
You may see the difference in the screenshots.
