### PR TITLE
fix: folding html element will include attributes and close element

### DIFF
--- a/treesit-fold.el
+++ b/treesit-fold.el
@@ -977,8 +977,10 @@ more information."
 
 For arguments NODE and OFFSET, see function `treesit-fold-range-seq' for
 more information."
-  (let* ((beg (treesit-node-end (treesit-node-child node 0)))
-         (end-node (treesit-fold-last-child node))
+  (let* (;; beg = after element name that follows open angle bracket
+         (beg (treesit-node-end (treesit-node-child (treesit-node-child node 0) 1)))
+         ;; end-node is the closing angle bracket
+         (end-node (treesit-node-child (treesit-fold-last-child node) 2))
          (end (treesit-node-start end-node)))
     (treesit-fold--cons-add (cons beg end) offset)))
 


### PR DESCRIPTION
For html-mode and html-ts-mode, without this change, treesit-fold folds from the END (closing angle bracket) of the opening element to the beginning (opening angle bracket) of the close element. That means attributes on the element are not included in the fold. Modern HTML can include lots of attributes.

Folding from the END of the opening element name to the END (closing angle bracket) of the closing element, will include attributes in the fold.

This change does that.

Before: 
![Screenshot 2025-07-08 6 27 16 PM](https://github.com/user-attachments/assets/485bec90-0b95-4ee4-8c63-7861e97f8359)

After: 
![Screenshot 2025-07-08 6 28 21 PM](https://github.com/user-attachments/assets/2e4bd62c-a5f4-44bd-b7e0-30a3fecd27be)
